### PR TITLE
feat(Mod List): improved filtering of enabled mods

### DIFF
--- a/Mod Manager/package-lock.json
+++ b/Mod Manager/package-lock.json
@@ -40,7 +40,6 @@
 				"semver": "^7.3.7",
 				"shiki": "^0.11.1",
 				"svelte-fa": "^2.4.0",
-				"svelte-sortable-list": "^1.1.0",
 				"svelte-tippy": "^1.3.2",
 				"tailwindcss": "^3.1.8",
 				"tippy.js": "^6.3.7",
@@ -7561,6 +7560,7 @@
 			"version": "3.49.0",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.49.0.tgz",
 			"integrity": "sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==",
+			"dev": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -7728,14 +7728,6 @@
 			"dev": true,
 			"dependencies": {
 				"sourcemap-codec": "^1.4.8"
-			}
-		},
-		"node_modules/svelte-sortable-list": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/svelte-sortable-list/-/svelte-sortable-list-1.1.0.tgz",
-			"integrity": "sha512-K8axS2OEJhN8KI/aXx1LEJkMGZTkR13U191nVhvN0BImZpNmFJ10Zy8K9T0EAg6chB6/hz3/hOeFoe2RVZylSw==",
-			"peerDependencies": {
-				"svelte": "^3.4.1"
 			}
 		},
 		"node_modules/svelte-tippy": {
@@ -14065,7 +14057,8 @@
 		"svelte": {
 			"version": "3.49.0",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.49.0.tgz",
-			"integrity": "sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA=="
+			"integrity": "sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==",
+			"dev": true
 		},
 		"svelte-check": {
 			"version": "2.8.0",
@@ -14154,12 +14147,6 @@
 					}
 				}
 			}
-		},
-		"svelte-sortable-list": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/svelte-sortable-list/-/svelte-sortable-list-1.1.0.tgz",
-			"integrity": "sha512-K8axS2OEJhN8KI/aXx1LEJkMGZTkR13U191nVhvN0BImZpNmFJ10Zy8K9T0EAg6chB6/hz3/hOeFoe2RVZylSw==",
-			"requires": {}
 		},
 		"svelte-tippy": {
 			"version": "1.3.2",

--- a/Mod Manager/package.json
+++ b/Mod Manager/package.json
@@ -57,7 +57,6 @@
 		"semver": "^7.3.7",
 		"shiki": "^0.11.1",
 		"svelte-fa": "^2.4.0",
-		"svelte-sortable-list": "^1.1.0",
 		"svelte-tippy": "^1.3.2",
 		"tailwindcss": "^3.1.8",
 		"tippy.js": "^6.3.7",

--- a/Mod Manager/src/lib/Mod.svelte
+++ b/Mod Manager/src/lib/Mod.svelte
@@ -13,13 +13,11 @@
 	export let manifest: Manifest = {} as Manifest
 	export let rpkgModName: string = ""
 
-	export let darken: boolean = false
-
 	let modWarnings: Promise<{ title: string; subtitle: string; trace: string }[]>
 	setTimeout(() => (modWarnings = getAllModWarnings()), 100)
 </script>
 
-<Tile style={darken ? "filter: brightness(0.75); transition: 250ms filter" : "transition: 250ms filter"}>
+<Tile style="transition: 250ms filter">
 	<div class="flex flex-row items-center gap-8">
 		<div class="flex-grow">
 			{#if isFrameworkMod}

--- a/Mod Manager/src/lib/SortableList.svelte
+++ b/Mod Manager/src/lib/SortableList.svelte
@@ -1,0 +1,113 @@
+<!--
+  from https://github.com/brunomolteni/svelte-sortable-list
+
+  changes:
+  - added disable property to forbid sorting
+-->
+<script>
+  import { quintOut } from "svelte/easing";
+  import { crossfade } from "svelte/transition";
+  import { flip } from "svelte/animate";
+
+  // FLIP ANIMATION
+  const [send, receive] = crossfade({
+    duration: d => Math.sqrt(d * 200),
+
+    fallback(node, params) {
+      const style = getComputedStyle(node);
+      const transform = style.transform === "none" ? "" : style.transform;
+
+      return {
+        duration: 600,
+        easing: quintOut,
+        css: t => `
+					transform: ${transform} scale(${t});
+					opacity: ${t}
+				`
+      };
+    }
+  });
+
+  // DRAG AND DROP
+  let isOver = false;
+  const getDraggedParent = node =>
+    node.dataset && node.dataset.index
+      ? node.dataset
+      : getDraggedParent(node.parentNode);
+  const start = ev => {
+    if(disable) return ev.preventDefault()
+    ev.dataTransfer.setData("source", ev.target.dataset.index);
+  };
+  const over = ev => {
+    ev.preventDefault();
+    let dragged = getDraggedParent(ev.target);
+    if (isOver !== dragged.id) isOver = JSON.parse(dragged.id);
+  };
+  const leave = ev => {
+    let dragged = getDraggedParent(ev.target);
+    if (isOver === dragged.id) isOver = false;
+  };
+  const drop = ev => {
+    isOver = false;
+    ev.preventDefault();
+    let dragged = getDraggedParent(ev.target);
+    let from = ev.dataTransfer.getData("source");
+    let to = dragged.index;
+    reorder({ from, to });
+  };
+
+  // DISPATCH REORDER
+  import { createEventDispatcher } from "svelte";
+  const dispatch = createEventDispatcher();
+  const reorder = ({ from, to }) => {
+    let newList = [...list];
+    newList[from] = [newList[to], (newList[to] = newList[from])][0];
+
+    dispatch("sort", newList);
+  };
+
+  // UTILS
+  const getKey = item => (key ? item[key] : item);
+
+  // PROPS
+  export let disable = false;
+  export let list;
+  export let key;
+</script>
+
+<style>
+  ul {
+    list-style: none;
+    padding: 0;
+  }
+  li {
+    border: 2px dotted transparent;
+    transition: border 0.1s linear;
+  }
+  .over {
+    border-color: rgba(48, 12, 200, 0.2);
+  }
+</style>
+
+{#if list && list.length}
+  <ul>
+    {#each list as item, index (getKey(item))}
+      <li
+        data-index={index}
+        data-id={JSON.stringify(getKey(item))}
+        draggable="true"
+        on:dragstart={start}
+        on:dragover={over}
+        on:dragleave={leave}
+        on:drop={drop}
+        in:receive={{ key: getKey(item) }}
+        out:send={{ key: getKey(item) }}
+        animate:flip={{ duration: 300 }}
+        class:over={getKey(item) === isOver}>
+        <slot {item} {index}>
+          <p>{getKey(item)}</p>
+        </slot>
+      </li>
+    {/each}
+  </ul>
+{/if}

--- a/Mod Manager/src/routes/modList.svelte
+++ b/Mod Manager/src/routes/modList.svelte
@@ -2,7 +2,7 @@
 	import { scale } from "svelte/transition"
 	import { flip } from "svelte/animate"
 
-	import SortableList from "svelte-sortable-list"
+	import SortableList from "$lib/SortableList.svelte"
 	import json5 from "json5"
 	import { Button, CodeSnippet, InlineNotification, Modal, Search } from "carbon-components-svelte"
 
@@ -273,6 +273,7 @@
 			<SortableList
 				list={enabledMods}
 				key="value"
+				disable={enabledModFilter?.length > 0}
 				on:sort={(event) => {
 					mergeConfig({
 						loadOrder: event.detail.map((a) => a.value)
@@ -282,38 +283,39 @@
 				}}
 				let:item
 			>
-				<div class="cursor-grab">
-					<Mod
-						isFrameworkMod={modIsFramework(item.value)}
-						manifest={modIsFramework(item.value) ? getManifestFromModID(item.value) : undefined}
-						rpkgModName={!modIsFramework(item.value) ? item.value : undefined}
-						darken={!((modIsFramework(item.value) ? getManifestFromModID(item.value).name : item.value) + (modIsFramework(item.value) ? getManifestFromModID(item.value).description : "")).toLowerCase().includes(enabledModFilter.toLowerCase())}
-					>
-						{#if modIsFramework(item.value) && getManifestFromModID(item.value)?.options?.filter((a) => a.type != OptionType.conditional)?.length}
-							<Button
-								kind="ghost"
-								icon={Settings}
-								iconDescription="Adjust this mod's settings"
-								on:click={() => {
-									goto(`/settings?mod=${getManifestFromModID(item.value).id}`)
-								}}
-							/>
-						{/if}
-						<Button
-							kind="danger"
-							icon={SubtractAlt}
-							on:click={() => {
-								mergeConfig({
-									loadOrder: getConfig().loadOrder.filter((a) => a != item.value)
-								})
-								forceModListsUpdate = Math.random()
-							}}
+				{#if ((modIsFramework(item.value) ? getManifestFromModID(item.value).name : item.value) + (modIsFramework(item.value) ? getManifestFromModID(item.value).description : "")).toLowerCase().includes(enabledModFilter.toLowerCase())}
+					<div title={enabledModFilter?.length > 0 ? 'Clear the filter to reorder your mods' : ''} class="{enabledModFilter?.length > 0 ? 'cursor-not-allowed' : 'cursor-grab'}">
+						<Mod
+							isFrameworkMod={modIsFramework(item.value)}
+							manifest={modIsFramework(item.value) ? getManifestFromModID(item.value) : undefined}
+							rpkgModName={!modIsFramework(item.value) ? item.value : undefined}
 						>
-							Disable
-						</Button>
-					</Mod>
-					<br />
-				</div>
+							{#if modIsFramework(item.value) && getManifestFromModID(item.value)?.options?.filter((a) => a.type != OptionType.conditional)?.length}
+								<Button
+									kind="ghost"
+									icon={Settings}
+									iconDescription="Adjust this mod's settings"
+									on:click={() => {
+										goto(`/settings?mod=${getManifestFromModID(item.value).id}`)
+									}}
+								/>
+							{/if}
+							<Button
+								kind="danger"
+								icon={SubtractAlt}
+								on:click={() => {
+									mergeConfig({
+										loadOrder: getConfig().loadOrder.filter((a) => a != item.value)
+									})
+									forceModListsUpdate = Math.random()
+								}}
+							>
+								Disable
+							</Button>
+						</Mod>
+						<br />
+					</div>
+				{/if}
 			</SortableList>
 		</div>
 	</div>


### PR DESCRIPTION
Currently, the filtering of the enabled mod list only grays out non-matches to prevent issues with the load order. This PR brings the filtering more in line with the available mod list filtering by only showing matches. To prevent the issues with the load order, you won't be able to resort mods while having an active filter. This however could easily lead to a misunderstanding which is why both the cursor & a tooltip tell the user that they need to clear the filter to resort their mods.