### PR TITLE
feat(deploy): Expose QuickEntity Script to mod scripts via mod API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "md5-file": "^5.0.0",
         "minimist": "^1.2.6",
         "promisify-child-process": "^4.1.1",
+        "quickentity-script": "^1.0.4",
         "rfc6902": "^5.0.1",
         "semver": "^7.3.8",
         "tslib": "^2.4.0",
@@ -1960,6 +1961,14 @@
         }
       ]
     },
+    "node_modules/quickentity-script": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/quickentity-script/-/quickentity-script-1.0.4.tgz",
+      "integrity": "sha512-M0Xl9QuvTrraA5vm3YKzsd3tTS7xS8uopoeEVgtQvQd60kRLAZk1JNix3R6lDpz9zo1LsS+TfTFiiiZb2TWDZQ==",
+      "dependencies": {
+        "md5": "^2.3.0"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -3711,6 +3720,14 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "quickentity-script": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/quickentity-script/-/quickentity-script-1.0.4.tgz",
+      "integrity": "sha512-M0Xl9QuvTrraA5vm3YKzsd3tTS7xS8uopoeEVgtQvQd60kRLAZk1JNix3R6lDpz9zo1LsS+TfTFiiiZb2TWDZQ==",
+      "requires": {
+        "md5": "^2.3.0"
+      }
     },
     "regexpp": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "md5-file": "^5.0.0",
     "minimist": "^1.2.6",
     "promisify-child-process": "^4.1.1",
+    "quickentity-script": "^1.0.4",
     "rfc6902": "^5.0.1",
     "semver": "^7.3.8",
     "tslib": "^2.4.0",

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -9,6 +9,7 @@ import { compileExpression, useDotAccessOperatorAndOptionalChaining } from "filt
 import { config, logger, rpkgInstance } from "./core-singleton"
 import { copyFromCache, copyToCache, extractOrCopyToTemp, getQuickEntityFromPatchVersion, getQuickEntityFromVersion, hexflip, isValidHash, normaliseToHash } from "./utils"
 
+import { createPatch as createQESPatch } from "quickentity-script"
 import { OptionType } from "./types"
 import Piscina from "piscina"
 import type { Transaction } from "@sentry/tracing"
@@ -408,6 +409,9 @@ export default async function deploy(
 										`-extract_from_rpkg "${path.join(config.runtimePath, `${rpkg}.rpkg`)}" -filter "${hash}" -output_path ${path.join(process.cwd(), "scriptTempFolder")}`
 									)
 								}
+							},
+							quickentityScript: {
+								createPatch: createQESPatch
 							},
 							utils: {
 								execCommand,


### PR DESCRIPTION
This exposes QNS ```createPatch```-function to mod scripts for easier QN patch synthesis in mod scripts.
[QNS on npmjs.com](https://npmjs.com/package/quickentity-script)