### PR TITLE
Dump the configurations indented

### DIFF
--- a/Mod Manager/src/lib/utils.ts
+++ b/Mod Manager/src/lib/utils.ts
@@ -130,7 +130,7 @@ export function getConfig() {
 }
 
 export function setConfig(config: Config) {
-	window.fs.writeFileSync("../config.json", json5.stringify(config))
+	window.fs.writeFileSync("../config.json", json5.stringify(config, undefined, 2))
 }
 
 export function mergeConfig(configToMerge: Partial<Config>) {


### PR DESCRIPTION
It just looks more friendly rather one being a one line blob.
I wanted to use regular json vs json5 for compatibility with other text editors, but was quite hesitant since your choice was json5 from the beginning.
Feel free to discard this if you want.