### PR TITLE
Update deploy.ts with the mis-spelling of RTLV fix

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1630,7 +1630,7 @@ export default async function deploy(
 								case "LOCR":
 									return `Converting localisation file ${contentIdentifier}`
 								case "RTLV":
-									return `Converting runtime video localisation file ${contentIdentifier}`
+									return `Converting runtime localised video file ${contentIdentifier}`
 								default:
 									return `` // We will never hit this, but stops typescript complaining
 							}

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1629,8 +1629,8 @@ export default async function deploy(
 									return `Converting dialogue file ${contentIdentifier}`
 								case "LOCR":
 									return `Converting localisation file ${contentIdentifier}`
-								case "RLTV":
-									return `Converting runtime video file ${contentIdentifier}`
+								case "RTLV":
+									return `Converting runtime video localisation file ${contentIdentifier}`
 								default:
 									return `` // We will never hit this, but stops typescript complaining
 							}


### PR DESCRIPTION
RTLV, not RLTV (Rocket League TeleVision?). Also adjusted the return text, as the L in RTLV clearly means Localisation, as before it implied it was the video file (GFXV), not the corresponding subtitles file (RTLV)

Yes, this was needlessly over-explained.