### PR TITLE
Add filtrex example of detecting mod options

### DIFF
--- a/docs/Manifest.md
+++ b/docs/Manifest.md
@@ -172,7 +172,7 @@ Each mod contains a manifest. Manifests have the following format:
 		{
 			"name": "Use epic content",
 			"type": "conditional", // This variation will be active if its condition returns true and inactive otherwise - it will not be shown in the GUI
-			"condition": "\"Atampy26.SomeOtherMod\" in config.loadOrder", // The condition is passed the framework's config; you can check the syntax at https://github.com/m93a/filtrex#expressions
+			"condition": "\"Atampy26.SomeOtherMod\" in config.loadOrder", // The condition is passed the framework's config; you can check the syntax at https://github.com/cshaa/filtrex#expressions
 			"contentFolders": ["epicContent"]
 		}
 	]

--- a/docs/Manifest.md
+++ b/docs/Manifest.md
@@ -170,10 +170,16 @@ Each mod contains a manifest. Manifests have the following format:
 			}
 		},
 		{
-			"name": "Use epic content",
+			"name": "Use epicContent if Atampy26.SomeOtherMod is loaded",
 			"type": "conditional", // This variation will be active if its condition returns true and inactive otherwise - it will not be shown in the GUI
-			"condition": "\"Atampy26.SomeOtherMod\" in config.loadOrder", // The condition is passed the framework's config; you can check the syntax at https://github.com/cshaa/filtrex#expressions
+			"condition": "\"Atampy26.SomeOtherMod\" in config.loadOrder", // The condition is passed the framework's config (see Config docs); you can check the syntax at https://github.com/cshaa/filtrex#expressions
 			"contentFolders": ["epicContent"]
+		},
+		{
+			"name": "Use awesomeContent only if two specific options are enabled",
+			"type": "conditional",
+			"condition": "\"Use additional content\" in ('Atampy26.ExampleMod' of config.modOptions) and \"Use lowercase or uppercase text:Uppercase text\" in ('Atampy26.ExampleMod' of config.modOptions)",
+			"contentFolders": ["awesomeContent"]
 		}
 	]
 }


### PR DESCRIPTION
Filtrex's `of` syntax (`Y of X` is syntactic sugar for `X.Y`) enables conditional options to detect complex mod option combinations which are otherwise impossible because `modOptions["Username.ModName"]` is not syntax that exists in filtrex, and `modOptions.Username.ModName` doesn't work for obvious reasons. But, this isn't at all obvious from the example in the docs - not to mention that the linked filtrex documentation is an abandoned repo that doesn't mention this syntax, and it isn't even the filtrex npm package that SMF uses.

This PR updates the filtrex expression docs link to point to the repo that provides the npm package, and adds an example of detecting mod option combinations.